### PR TITLE
Run pipeline off of old module versions

### DIFF
--- a/cap2/capalyzer/table_builder/modules/basic_stats_summary.py
+++ b/cap2/capalyzer/table_builder/modules/basic_stats_summary.py
@@ -1,0 +1,37 @@
+
+import pandas as pd
+import json
+import logging
+from ..base_module import BaseModule
+from ..parsers import parse_taxa_report
+
+logger = logging.getLogger(__name__)  # Same name as calling module
+
+
+def flatten_dict(d):
+    for k, v in d.items():
+        if isinstance(v, dict):
+            for sub_k, sub_v in flatten_dict(v):
+                yield [k] + sub_k, sub_v
+        else:
+            yield [k], v
+
+
+class BasicStatsTableModule(BaseModule):
+    result_name = 'basic_stats_table'
+    field_name = 'report'
+    source_result_name = 'cap2::basic_sample_stats'
+
+    @classmethod
+    def build_result(cls, file_source):
+        tbl = {}
+        fs = file_source(cls.source_result_name, cls.field_name)
+        for i, (sample_name, report_path) in enumerate(fs):
+            try:
+                report = json.loads(open(report_path).read())
+                tbl[sample_name] = {tuple(k): v for k, v in flatten_dict(report)}
+                logger.debug(f'[BasicStats] Parsed {sample_name} ({i + 1})')
+            except Exception as e:
+                logger.debug(f'[BasicStats] failed to parse "{sample_name}". Exception: {e}')
+        tbl = pd.DataFrame.from_dict(tbl, orient='index')
+        return tbl, tbl.shape[0]

--- a/cap2/capalyzer/table_builder/modules/kraken2_covid_fast_detect.py
+++ b/cap2/capalyzer/table_builder/modules/kraken2_covid_fast_detect.py
@@ -2,6 +2,7 @@
 import pandas as pd
 import logging
 from ..base_module import BaseModule
+from ..parsers import parse_taxa_report
 
 logger = logging.getLogger(__name__)  # Same name as calling module
 

--- a/cap2/capalyzer/table_builder/modules/kraken2_fast_taxa.py
+++ b/cap2/capalyzer/table_builder/modules/kraken2_fast_taxa.py
@@ -1,0 +1,31 @@
+
+import pandas as pd
+import logging
+from ..base_module import BaseModule
+from ..parsers import parse_taxa_report
+
+logger = logging.getLogger(__name__)  # Same name as calling module
+
+
+class FastKraken2TableModule(BaseModule):
+    result_name = 'fast_kraken2_taxa'
+    field_name = 'report'
+    source_result_name = 'cap2::fast_kraken2'
+
+    @classmethod
+    def build_result(cls, file_source):
+        taxa = {}
+        fs = file_source(cls.source_result_name, cls.field_name)
+        for i, (sample_name, report_path) in enumerate(fs):
+            try:
+                taxa[sample_name] = parse_taxa_report(
+                    report_path,
+                    normalize=True,
+                    minimum_abundance=0.001,
+                    species_only=True,
+                )
+                logger.debug(f'[FastTaxa] Parsed {sample_name} ({i + 1})')
+            except Exception as e:
+                logger.debug(f'[FastTaxa] failed to parse "{sample_name}". Exception: {e}')
+        taxa = pd.DataFrame.from_dict(taxa, orient='index')
+        return taxa, taxa.shape[0]

--- a/cap2/extensions/experimental/covid/cli.py
+++ b/cap2/extensions/experimental/covid/cli.py
@@ -164,7 +164,7 @@ def cli_run_samples(config, log_level, clean_reads, upload, download_only, sched
                     batch_size, workers, threads, timelimit,
                     endpoint, email, password, stage, random_seed,
                     org_name, grp_name):
-    set_config(endpoint, email, password, org_name, grp_name)
+    set_config(endpoint, email, password, org_name, grp_name, upload_allowed=upload, download_only=download_only, name_is_uuid=True)
     group = PangeaGroup(grp_name, email, password, endpoint, org_name)
     samples = [
         samp for samp in group.pangea_samples(randomize=True, seed=random_seed)

--- a/cap2/pangea/load_task.py
+++ b/cap2/pangea/load_task.py
@@ -225,7 +225,11 @@ class PangeaCapTask(PangeaBaseCapTask):
         ).download()
 
     def results_available_for_version(self, version_str, version_hash):
-        """Check for results of a specific version on Pangea."""
+        """Check for results of a specific version on Pangea.
+
+        Side effect: if the results are found we set the wrapped
+        instance to point at those results.
+        """
         original_wrapped_task = self.wrapped_instance
         clone = self.wrapped_type.from_cap_task(self.wrapped_instance, check_versions=False)
         clone.version_override = version_str, version_hash

--- a/cap2/pipeline/config.py
+++ b/cap2/pipeline/config.py
@@ -23,3 +23,14 @@ class PipelineConfig:
         )
 
         self.exc_metaspades = self.blob.get('EXC_METASPADES', None)
+        self.module_versions = self.blob.get('module_version', {})
+
+    def allowed_versions(self, module):
+        """Return a list of the allowed versions for the specified module."""
+        module_name = module.module_name()
+        if module_name not in self.module_versions:
+            module_name = module._module_name()
+        if module_name not in self.module_versions:
+            return []
+        versions = self.module_versions[module_name]
+        return versions

--- a/cap2/pipeline/databases/fast_kraken2_db.py
+++ b/cap2/pipeline/databases/fast_kraken2_db.py
@@ -15,6 +15,7 @@ MINIKRAKEN_V2_8GB_URL = 'ftp://ftp.ccb.jhu.edu/pub/data/kraken2_dbs/old/minikrak
 class FastKraken2DB(CapDbTask):
     config_filename = luigi.Parameter()
     cores = luigi.IntParameter(default=1)
+    MODULE_VERSION = 'v0.1.0'
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -33,10 +34,6 @@ class FastKraken2DB(CapDbTask):
     @classmethod
     def _module_name(cls):
         return 'fast_kraken2_taxa_db'
-
-    @classmethod
-    def version(cls):
-        return 'v0.1.0'
 
     @classmethod
     def dependencies(cls):

--- a/cap2/pipeline/databases/hmp_db.py
+++ b/cap2/pipeline/databases/hmp_db.py
@@ -14,6 +14,7 @@ class HmpDB(CapDbTask):
 
     config_filename = luigi.Parameter()
     cores = luigi.IntParameter(default=1)
+    MODULE_VERSION = 'v1.0.0'
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -34,10 +35,6 @@ class HmpDB(CapDbTask):
     @classmethod
     def _module_name(cls):
         return 'mash_hmp_db'
-
-    @classmethod
-    def version(cls):
-        return 'v1.0.0'
 
     @classmethod
     def dependencies(cls):

--- a/cap2/pipeline/databases/human_removal_db.py
+++ b/cap2/pipeline/databases/human_removal_db.py
@@ -16,6 +16,7 @@ class HumanRemovalDB(CapDbTask):
     """
     config_filename = luigi.Parameter()
     cores = luigi.IntParameter(default=1)
+    MODULE_VERSION = 'v1.0.0'
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/cap2/pipeline/databases/kraken2_db.py
+++ b/cap2/pipeline/databases/kraken2_db.py
@@ -182,10 +182,6 @@ class BrakenKraken2DB(CapDbTask):
         return 'bracken_kraken2_taxa_db'
 
     @classmethod
-    def version(cls):
-        return 'v0.1.0'
-
-    @classmethod
     def dependencies(cls):
         return ['bracken', DB_DATE, Kraken2DB]
 

--- a/cap2/pipeline/databases/kraken2_db.py
+++ b/cap2/pipeline/databases/kraken2_db.py
@@ -18,6 +18,7 @@ DB_DATE = '2020-06-01'
 class Kraken2DBDataDown(CapDbTask):
     config_filename = luigi.Parameter()
     cores = luigi.IntParameter(default=1)
+    MODULE_VERSION = 'v0.1.0'
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -44,10 +45,6 @@ class Kraken2DBDataDown(CapDbTask):
     @classmethod
     def _module_name(cls):
         return 'kraken2_taxa_db_down'
-
-    @classmethod
-    def version(cls):
-        return 'v0.1.0'
 
     @classmethod
     def dependencies(cls):
@@ -85,6 +82,7 @@ class Kraken2DBDataDown(CapDbTask):
 class Kraken2DB(CapDbTask):
     config_filename = luigi.Parameter()
     cores = luigi.IntParameter(default=1)
+    MODULE_VERSION = 'v0.1.0'
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -108,10 +106,6 @@ class Kraken2DB(CapDbTask):
     @classmethod
     def _module_name(cls):
         return 'kraken2_taxa_db'
-
-    @classmethod
-    def version(cls):
-        return 'v0.1.0'
 
     @classmethod
     def dependencies(cls):
@@ -162,6 +156,7 @@ class Kraken2DB(CapDbTask):
 class BrakenKraken2DB(CapDbTask):
     config_filename = luigi.Parameter()
     cores = luigi.IntParameter(default=1)
+    MODULE_VERSION = 'v0.1.0'
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/cap2/pipeline/databases/mouse_removal_db.py
+++ b/cap2/pipeline/databases/mouse_removal_db.py
@@ -19,6 +19,7 @@ class MouseRemovalDB(CapDbTask):
     """
     config_filename = luigi.Parameter()
     cores = luigi.IntParameter(default=1)
+    MODULE_VERSION = 'v1.0.0'
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -61,10 +62,6 @@ class MouseRemovalDB(CapDbTask):
     @classmethod
     def _module_name(cls):
         return 'bowtie_mouse_removal_db'
-
-    @classmethod
-    def version(cls):
-        return 'v1.0.0'
 
     @classmethod
     def dependencies(cls):

--- a/cap2/pipeline/databases/taxonomic_db.py
+++ b/cap2/pipeline/databases/taxonomic_db.py
@@ -35,11 +35,7 @@ class TaxonomicDB(CapDbTask):
 
     @classmethod
     def _module_name(cls):
-        return 'krakenuniq_taxa_db'
-
-    @classmethod
-    def version(cls):
-        return 'v1.0.0'
+        return 'krakenuniq_taxa_db'MODULE_VERSION =
 
     @classmethod
     def dependencies(cls):

--- a/cap2/pipeline/databases/taxonomic_db.py
+++ b/cap2/pipeline/databases/taxonomic_db.py
@@ -13,6 +13,7 @@ from ..utils.cap_task import CapDbTask
 class TaxonomicDB(CapDbTask):
     config_filename = luigi.Parameter()
     cores = luigi.IntParameter(default=1)
+    MODULE_VERSION = 'v1.0.0'
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/cap2/pipeline/databases/taxonomic_db.py
+++ b/cap2/pipeline/databases/taxonomic_db.py
@@ -35,7 +35,7 @@ class TaxonomicDB(CapDbTask):
 
     @classmethod
     def _module_name(cls):
-        return 'krakenuniq_taxa_db'MODULE_VERSION =
+        return 'krakenuniq_taxa_db'
 
     @classmethod
     def dependencies(cls):

--- a/cap2/pipeline/databases/uniref.py
+++ b/cap2/pipeline/databases/uniref.py
@@ -13,6 +13,7 @@ from ..utils.cap_task import CapDbTask
 class Uniref90(CapDbTask):
     config_filename = luigi.Parameter()
     cores = luigi.IntParameter(default=1)
+    MODULE_VERSION = 'v1.0.0'
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -41,10 +42,6 @@ class Uniref90(CapDbTask):
     @classmethod
     def _module_name(cls):
         return 'diamond_uniref_db'
-
-    @classmethod
-    def version(cls):
-        return 'v1.0.0'
 
     @classmethod
     def dependencies(cls):

--- a/cap2/pipeline/preprocessing/base_reads.py
+++ b/cap2/pipeline/preprocessing/base_reads.py
@@ -7,6 +7,7 @@ from ..utils.cap_task import CapTask
 class BaseReads(CapTask):
     """This class represents the start of the pipeline.
     """
+    MODULE_VERSION = 'v1.0.0'
     module_description = """
     This module contains paired end short reads.
 
@@ -15,10 +16,6 @@ class BaseReads(CapTask):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-
-    @classmethod
-    def version(cls):
-        return 'v1.0.0'
 
     @classmethod
     def dependencies(cls):

--- a/cap2/pipeline/preprocessing/basic_sample_stats.py
+++ b/cap2/pipeline/preprocessing/basic_sample_stats.py
@@ -34,6 +34,7 @@ class BasicSampleStats(CapTask):
     based on the taxonomic profiles.
     """
     READ_STATS_DROPOUT = 1 / 1000
+    MODULE_VERSION = 'v0.1.0'
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -52,10 +53,6 @@ class BasicSampleStats(CapTask):
 
     def requires(self):
         return self.taxa, self.reads
-
-    @classmethod
-    def version(cls):
-        return 'v0.1.0'
 
     @classmethod
     def dependencies(cls):

--- a/cap2/pipeline/preprocessing/clean_reads.py
+++ b/cap2/pipeline/preprocessing/clean_reads.py
@@ -13,6 +13,7 @@ class CleanReads(CapTask):
     """This class represents the culmination of the
     preprocessing pipeline.
     """
+    MODULE_VERSION = 'v0.2.1'
     module_description = """
     This module contains cleaned paired end short reads.
 
@@ -26,10 +27,6 @@ class CleanReads(CapTask):
     @property
     def reads(self):
         return self.ec_reads
-
-    @classmethod
-    def version(cls):
-        return 'v0.2.1'
 
     @classmethod
     def dependencies(cls):

--- a/cap2/pipeline/preprocessing/count_reads.py
+++ b/cap2/pipeline/preprocessing/count_reads.py
@@ -11,6 +11,7 @@ class CountRawReads(CapTask):
     module_description = """
     This module counts the number of reads in the sample.
     """
+    MODULE_VERSION = 'v1.0.0'
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -21,10 +22,6 @@ class CountRawReads(CapTask):
     @classmethod
     def _module_name(cls):
         return 'count_raw_reads'
-
-    @classmethod
-    def version(cls):
-        return 'v1.0.0'
 
     @classmethod
     def dependencies(cls):

--- a/cap2/pipeline/preprocessing/error_correct_reads.py
+++ b/cap2/pipeline/preprocessing/error_correct_reads.py
@@ -25,6 +25,7 @@ class ErrorCorrectReads(CapTask):
     secondary strains, as such error corrected reads should
     not be used to call SNPs.
     """
+    MODULE_VERSION = 'v0.2.2'
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -40,10 +41,6 @@ class ErrorCorrectReads(CapTask):
 
     def requires(self):
         return self.pkg, self.nonhuman_reads
-
-    @classmethod
-    def version(cls):
-        return 'v0.2.2'
 
     def tool_version(self):
         return self.run_cmd(f'{self.pkg.bin} --version').stderr.decode('utf-8')

--- a/cap2/pipeline/preprocessing/fast_taxa.py
+++ b/cap2/pipeline/preprocessing/fast_taxa.py
@@ -23,6 +23,7 @@ class FastKraken2(CapTask):
     and specific than true alignment. This module uses a small database on
     uncleaned reads. It is fast but not terribly accurate.
     """
+    MODULE_VERSION = 'v0.1.0'
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -54,10 +55,6 @@ class FastKraken2(CapTask):
 
     def requires(self):
         return self.rsync_pkg, self.pkg, self.db, self.reads
-
-    @classmethod
-    def version(cls):
-        return 'v0.1.0'
 
     @classmethod
     def dependencies(cls):

--- a/cap2/pipeline/preprocessing/fastqc.py
+++ b/cap2/pipeline/preprocessing/fastqc.py
@@ -20,6 +20,7 @@ class FastQC(CapTask):
     Negatives: FastQC only runs on a subset of reads though
     this is usually sufficient.
     """
+    MODULE_VERSION = 'v0.2.1'
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -39,10 +40,6 @@ class FastQC(CapTask):
 
     def tool_version(self):
         return self.run_cmd(f'{self.pkg.bin} --version').stderr.decode('utf-8')
-
-    @classmethod
-    def version(cls):
-        return 'v0.2.1'
 
     @classmethod
     def dependencies(cls):

--- a/cap2/pipeline/preprocessing/map_to_human.py
+++ b/cap2/pipeline/preprocessing/map_to_human.py
@@ -23,6 +23,7 @@ class RemoveHumanReads(CapTask):
     human DNA may actually be microbial though in most cases
     part of the microbial genome will not resemble human.
     """
+    MODULE_VERSION = 'v0.2.1'
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -45,10 +46,6 @@ class RemoveHumanReads(CapTask):
 
     def requires(self):
         return self.samtools, self.pkg, self.db, self.mouse_removed_reads
-
-    @classmethod
-    def version(cls):
-        return 'v0.2.1'
 
     def tool_version(self):
         version = '[BOWTIE2]\n'

--- a/cap2/pipeline/preprocessing/map_to_mouse.py
+++ b/cap2/pipeline/preprocessing/map_to_mouse.py
@@ -24,6 +24,7 @@ class RemoveMouseReads(CapTask):
 
     Removing mouse DNA may obscure human DNA in the sample.
     """
+    MODULE_VERSION = 'v0.1.0'
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -46,10 +47,6 @@ class RemoveMouseReads(CapTask):
 
     def requires(self):
         return self.samtools, self.pkg, self.db, self.adapter_removed_reads
-
-    @classmethod
-    def version(cls):
-        return 'v0.1.0'
 
     def tool_version(self):
         version = '[BOWTIE2]\n'

--- a/cap2/pipeline/preprocessing/multiqc.py
+++ b/cap2/pipeline/preprocessing/multiqc.py
@@ -16,6 +16,7 @@ class MultiQC(CapGroupTask):
     module_description = """
     MultiQC condenses the results of FastQC.
     """
+    MODULE_VERSION = 'v0.2.0'
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -26,10 +27,6 @@ class MultiQC(CapGroupTask):
 
     def requires(self):
         return self.fastqcs
-
-    @classmethod
-    def version(cls):
-        return 'v0.2.0'
 
     @classmethod
     def dependencies(cls):

--- a/cap2/pipeline/preprocessing/remove_adapters.py
+++ b/cap2/pipeline/preprocessing/remove_adapters.py
@@ -22,6 +22,7 @@ class AdapterRemoval(CapTask):
     identified.
     """
     ILLUMINA_SHARED_PREFIX = 'AGATCGGAAGAGC'
+    MODULE_VERSION = 'v0.2.1'
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -39,10 +40,6 @@ class AdapterRemoval(CapTask):
 
     def requires(self):
         return self.pkg, self.reads
-
-    @classmethod
-    def version(cls):
-        return 'v0.2.1'
 
     def tool_version(self):
         return self.run_cmd(f'{self.pkg.bin} --version').stderr.decode('utf-8')

--- a/cap2/pipeline/short_read/hmp_comparison.py
+++ b/cap2/pipeline/short_read/hmp_comparison.py
@@ -20,6 +20,7 @@ class HmpComparison(CapTask):
     Negatives: HMP samples are a useful reference but do not provide
     the full gamut of human microbiome diversity.
     """
+    MODULE_VERSION = 'v0.3.0'
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -40,10 +41,6 @@ class HmpComparison(CapTask):
 
     def requires(self):
         return self.pkg, self.db, self.mash
-
-    @classmethod
-    def version(cls):
-        return 'v0.3.0'
 
     @classmethod
     def dependencies(cls):

--- a/cap2/pipeline/short_read/humann2.py
+++ b/cap2/pipeline/short_read/humann2.py
@@ -22,6 +22,7 @@ class MicaUniref90(CapTask):
 
     Note: this module currently uses Diamond not MiCA
     """
+    MODULE_VERSION = 'v0.2.0'
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -45,10 +46,6 @@ class MicaUniref90(CapTask):
     @classmethod
     def _module_name(cls):
         return 'diamond'
-
-    @classmethod
-    def version(cls):
-        return 'v0.2.0'
 
     @classmethod
     def dependencies(cls):
@@ -86,6 +83,7 @@ class Humann2(CapTask):
     Notes: This class is named Humann2 for historical reasons. It uses
     humann3
     """
+    MODULE_VERSION = 'v0.3.0'
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -108,10 +106,6 @@ class Humann2(CapTask):
     @classmethod
     def _module_name(cls):
         return 'humann'
-
-    @classmethod
-    def version(cls):
-        return 'v0.3.0'
 
     @classmethod
     def dependencies(cls):

--- a/cap2/pipeline/short_read/jellyfish.py
+++ b/cap2/pipeline/short_read/jellyfish.py
@@ -23,6 +23,7 @@ class Jellyfish(CapTask):
     Negatives: K-mer counts can be large and are sensitive to read errors. The latter is
     mitigated somewhat by read error correction.
     """
+    MODULE_VERSION = 'v0.2.0'
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -45,10 +46,6 @@ class Jellyfish(CapTask):
 
     def requires(self):
         return self.pkg, self.reads
-
-    @classmethod
-    def version(cls):
-        return 'v0.2.0'
 
     @classmethod
     def dependencies(cls):

--- a/cap2/pipeline/short_read/kraken2.py
+++ b/cap2/pipeline/short_read/kraken2.py
@@ -22,6 +22,7 @@ class Kraken2(CapTask):
     Negatives: Kraken2 uses pseudo-alignment which is somewhat less sensitive
     and specific than true alignment.
     """
+    MODULE_VERSION = 'v0.3.0'
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -55,10 +56,6 @@ class Kraken2(CapTask):
         return self.rsync_pkg, self.pkg, self.db, self.reads
 
     @classmethod
-    def version(cls):
-        return 'v0.3.0'
-
-    @classmethod
     def dependencies(cls):
         return ['kraken2', Kraken2DB, CleanReads]
 
@@ -84,6 +81,7 @@ class Kraken2(CapTask):
 
 
 class BrakenKraken2(CapTask):
+    MODULE_VERSION = 'v0.1.0'
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -115,10 +113,6 @@ class BrakenKraken2(CapTask):
 
     def requires(self):
         return self.pkg, self.report, self.db, self.reads
-
-    @classmethod
-    def version(cls):
-        return 'v0.1.0'
 
     @classmethod
     def dependencies(cls):

--- a/cap2/pipeline/short_read/mash.py
+++ b/cap2/pipeline/short_read/mash.py
@@ -22,6 +22,7 @@ class Mash(CapTask):
     Negatives: Small MASH sketch sizes can obscure differences between
     samples. As such this module produces two different sketch sizes.
     """
+    MODULE_VERSION = 'v0.2.0'
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -44,10 +45,6 @@ class Mash(CapTask):
 
     def requires(self):
         return self.pkg, self.reads
-
-    @classmethod
-    def version(cls):
-        return 'v0.2.0'
 
     @classmethod
     def dependencies(cls):

--- a/cap2/pipeline/short_read/processed_reads.py
+++ b/cap2/pipeline/short_read/processed_reads.py
@@ -17,6 +17,7 @@ class ProcessedReads(CapTask):
     module_description = """
     This module is a proxy for the end of the short read stage.
     """
+    MODULE_VERSION = 'v0.2.1'
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -26,10 +27,6 @@ class ProcessedReads(CapTask):
         self.mash = Mash.from_cap_task(self)
         self.jellyfish = Jellyfish.from_cap_task(self)
         self.read_stats = ReadStats.from_cap_task(self)
-
-    @classmethod
-    def version(cls):
-        return 'v0.2.1'
 
     @classmethod
     def dependencies(cls):

--- a/cap2/pipeline/short_read/read_stats.py
+++ b/cap2/pipeline/short_read/read_stats.py
@@ -17,6 +17,7 @@ class ReadStats(CapTask):
 
     Motivation: Read statistics can help uncover basic patterns.
     """
+    MODULE_VERSION = 'v1.0.1'
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -31,10 +32,6 @@ class ReadStats(CapTask):
 
     def requires(self):
         return self.reads
-
-    @classmethod
-    def version(cls):
-        return 'v1.0.1'
 
     @classmethod
     def dependencies(cls):

--- a/cap2/pipeline/utils/cap_task.py
+++ b/cap2/pipeline/utils/cap_task.py
@@ -17,6 +17,13 @@ logger = logging.getLogger('cap2')
 
 
 class class_or_instancemethod(classmethod):
+    """Decorator that provides similar functionality to classmethod
+
+    For our use case this allows us to overwrite class level
+    values in instances. this is important for spoofing the
+    versions of old modules.
+    """
+
     def __get__(self, instance, type_):
         descr_get = self.__func__.__get__
         if instance is None:
@@ -41,7 +48,6 @@ class BaseCapTask(luigi.Task):
         self.out_dir = self.config.out_dir
         self.pre_run_hooks = []
         self.version_override = None
-
 
         # Check if any of the allowed version already exist
         # If they do we spoof that version in.

--- a/cap2/pipeline/utils/cap_task.py
+++ b/cap2/pipeline/utils/cap_task.py
@@ -1,5 +1,6 @@
 
 import luigi
+import types
 import subprocess
 import datetime
 import json
@@ -15,11 +16,21 @@ from ..config import PipelineConfig
 logger = logging.getLogger('cap2')
 
 
+class class_or_instancemethod(classmethod):
+    def __get__(self, instance, type_):
+        descr_get = self.__func__.__get__
+        if instance is None:
+            descr_get = super().__get__
+        return descr_get(instance, type_)
+
+
 class BaseCapTask(luigi.Task):
     config_filename = luigi.Parameter(default='')
     cores = luigi.IntParameter(default=1)
     max_ram = luigi.IntParameter(default=0)  # maximum allowed ram in GB. 0 means no limit.
+    check_versions = luigi.BoolParameter(default=True)
     module_description = "No description for this module."
+    MODULE_VERSION = None
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -29,6 +40,7 @@ class BaseCapTask(luigi.Task):
         self.config = PipelineConfig(self.config_filename)
         self.out_dir = self.config.out_dir
         self.pre_run_hooks = []
+        self.version_override = None
 
         # Check if any of the allowed version already exist
         # If they do we spoof that version in.
@@ -37,14 +49,19 @@ class BaseCapTask(luigi.Task):
         # or changed this will not find an old version
         # (Indeed that would introduce difficult dependency
         # issues if downstreams relied on the new fields)
-        for version_str in self.config.allowed_versions(self):
-            if self.version_exists(version_str):
-                self.version = lambda: version_str
-                break
+        if self.check_versions:
+            for version_str in self.config.allowed_versions(self):
+                if self.version_exists(version_str):
+                    self.version_override = version_str
+                    break
 
-    @classmethod
+    @class_or_instancemethod
     def version(cls):
         """Return a string giving a human readable version for this module only."""
+        if hasattr(cls, 'version_override') and cls.version_override:
+            return cls.version_override
+        elif cls.MODULE_VERSION:
+            return cls.MODULE_VERSION
         raise NotImplementedError()
 
     @classmethod
@@ -55,7 +72,7 @@ class BaseCapTask(luigi.Task):
         """
         raise NotImplementedError()
 
-    @classmethod
+    @class_or_instancemethod
     def version_tree(cls, terminal=True):
         """Return a newick tree with versions."""
         out = f'{cls.module_name()}=={cls.version()}'
@@ -70,7 +87,7 @@ class BaseCapTask(luigi.Task):
             out += ';'
         return out
 
-    @classmethod
+    @class_or_instancemethod
     def version_hash(cls):
         """Return a hash string giving the version of this task and all upstream tasks."""
         try:
@@ -86,7 +103,7 @@ class BaseCapTask(luigi.Task):
             out += result.hexdigest()
         return out
 
-    @classmethod
+    @class_or_instancemethod
     def short_version_hash(cls):
         """Return a 12 character hash string giving the version of this task and all upstream tasks."""
         myhash = cls.version_hash()
@@ -178,15 +195,16 @@ class CapDbTask(BaseCapTask):
         )
 
     @classmethod
-    def from_cap_db_task(cls, other):
+    def from_cap_db_task(cls, other, **kwargs):
         return cls(
             config_filename=other.config_filename,
             cores=other.cores,
+            **kwargs,
         )
 
     def version_exists(self, version):
         """Return True iff this verion of this module already exists."""
-        clone = type(self).from_cap_db_task(self)
+        clone = type(self).from_cap_db_task(self, check_versions=False)
         clone.version = lambda: version
         return clone.complete()
 
@@ -229,8 +247,8 @@ class CapTask(BaseCapTask):
         )
 
     @classmethod
-    def from_cap_task(cls, other):
-        return cls(
+    def from_cap_task(cls, other, **kwargs):
+        out = cls(
             pe1=other.pe1,
             pe2=other.pe2,
             sample_name=other.sample_name,
@@ -238,7 +256,9 @@ class CapTask(BaseCapTask):
             cores=other.cores,
             max_ram=other.max_ram,
             data_type=other.data_type,
+            **kwargs,
         )
+        return out
 
     def __str__(self):
         try:
@@ -250,9 +270,10 @@ class CapTask(BaseCapTask):
 
     def version_exists(self, version):
         """Return True iff this verion of this module already exists."""
-        clone = type(self).from_cap_task(self)
-        clone.version = lambda: version
-        return clone.complete()
+        clone = type(self).from_cap_task(self, check_versions=False)
+        clone.version_override = version
+        is_complete = clone.complete()
+        return is_complete
 
 
 class CapGroupTask(BaseCapTask):
@@ -298,17 +319,18 @@ class CapGroupTask(BaseCapTask):
         )
 
     @classmethod
-    def from_cap_group_task(cls, other):
+    def from_cap_group_task(cls, other, **kwargs):
         return cls(
             group_name=other.group_name,
             config_filename=other.config_filename,
             cores=other.cores,
             max_ram=other.max_ram,
             samples=other.samples,
+            **kwargs,
         )
 
     def version_exists(self, version):
         """Return True iff this verion of this module already exists."""
-        clone = type(self).from_cap_group_task(self)
+        clone = type(self).from_cap_group_task(self, check_versions=False)
         clone.version = lambda: version
         return clone.complete()

--- a/cap2/setup_logging.py
+++ b/cap2/setup_logging.py
@@ -16,30 +16,31 @@ def run_once(f):
 @run_once
 def setup_logging():
     luigi.configuration.get_config().set('core', 'no_configure_logging', 'True')
-    
+
     luigi_logger = logging.getLogger('luigi-interface')
     luigi_logger.setLevel(LEVEL)
-
     stream_handler = logging.StreamHandler()
     stream_handler.setLevel(LEVEL)
-
     formatter = logging.Formatter('[%(levelname)s] <luigi> (%(asctime)s): %(message)s')
     stream_handler.setFormatter(formatter)
-
     luigi_logger.handlers = []  # get rid of anything in luigi
     luigi_logger.addHandler(stream_handler)
 
-
     cap2_logger = logging.getLogger('cap2')
     cap2_logger.setLevel(LEVEL)
-
     stream_handler = logging.StreamHandler()
     stream_handler.setLevel(LEVEL)
-
     formatter = logging.Formatter('[%(levelname)s] <cap2> (%(asctime)s): %(message)s')
     stream_handler.setFormatter(formatter)
-
     cap2_logger.addHandler(stream_handler)
+
+    module_logger = logging.getLogger(__name__)
+    module_logger.setLevel(LEVEL)
+    stream_handler = logging.StreamHandler()
+    stream_handler.setLevel(LEVEL)
+    formatter = logging.Formatter('[%(levelname)s] <' + __name__ + '> (%(asctime)s): %(message)s')
+    stream_handler.setFormatter(formatter)
+    module_logger.addHandler(stream_handler)
 
 
 setup_logging()

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setuptools.setup(
         'click==6.7',
         'Jinja2==3.0.0a1',  # for multiqc
         'multiqc==1.8',  # hackish, tbd if I'm okay with this
-        'pangea_api>=0.8.12',
+        'pangea_api>=0.9.0',
         'pysam',
         'python-louvain',
         'gimmebio.seqs',

--- a/tests/data/test_config.yaml
+++ b/tests/data/test_config.yaml
@@ -1,3 +1,5 @@
 out_dir: test_out
 db_dir: test_db
 db_mode: build
+module_version:
+  test_flag: B

--- a/tests/data/test_config.yaml
+++ b/tests/data/test_config.yaml
@@ -2,4 +2,4 @@ out_dir: test_out
 db_dir: test_db
 db_mode: build
 module_version:
-  test_flag: B
+  test_flag: [[B, df7e70e5021544f4834bbee64a9e3789febc4be81470df629cad6ddb03320a5c]]

--- a/tests/test_pangea.py
+++ b/tests/test_pangea.py
@@ -1,25 +1,32 @@
 
 import luigi
 
-from os import environ
+from os import environ, remove
 
-from time import time
+from time import time, sleep
 from cap2.pangea.load_task import PangeaCapTask
 from cap2.pipeline.preprocessing import FastQC
 from unittest import TestCase
 from cap2.pangea.cli import set_config
-from cap2.pangea.api import get_task_list_for_sample
+from cap2.pangea.api import get_task_list_for_sample, wrap_task, recursively_wrap_task
 from cap2.pangea.pangea_sample import PangeaSample
 from os.path import join, dirname, isfile, isdir, abspath
 
 from pangea_api.blob_constructors import sample_from_uuid
 from pangea_api import Knex, Organization, User
 
+from .test_versions import (
+    FlagTaskVersionA,
+    FlagTaskVersionB,
+    TaskThatReliesOnFlagTask,
+)
+
 RAW_READS_1 = join(dirname(__file__), 'data/zymo_pos_cntrl.r1.fq.gz')
 RAW_READS_2 = join(dirname(__file__), 'data/zymo_pos_cntrl.r2.fq.gz')
+TEST_CONFIG = join(dirname(__file__), 'data/test_config.yaml')
 
 PANGEA_ENDPOINT = 'https://pangea.gimmebio.com'
-PANGEA_USER = 'cap2tester@fake.com'
+PANGEA_USER = 'dcdanko@gmail.com'  #'cap2tester@fake.com'
 PANGEA_PASS = environ['CAP2_PANGEA_TEST_PASSWORD']
 
 
@@ -148,3 +155,28 @@ class TestPangea(TestCase):
         tasks[0].taxa = DummyFastKraken2()
         luigi.build(tasks, local_scheduler=True)
         self.assertTrue(PANGEA_SAMPLE.analysis_result('cap2::basic_sample_stats').exists())
+
+    def test_pangea_versions(self):
+        psample = PangeaSample(
+            PANGEA_SAMPLE.uuid,
+            None,
+            None,
+            None,
+            None,
+            None,
+            knex=PANGEA_SAMPLE.knex,
+            sample=PANGEA_SAMPLE,
+        )
+        set_config(PANGEA_ENDPOINT, PANGEA_USER, PANGEA_PASS, '', '', name_is_uuid=True)
+        wrapped_flag_b = wrap_task(psample, FlagTaskVersionB, config_path=TEST_CONFIG, check_versions=False)
+        luigi.build([wrapped_flag_b], local_scheduler=True)
+        remove(wrapped_flag_b.flag_filepath)
+        self.assertTrue(PANGEA_SAMPLE.analysis_result(
+            'cap2::test_flag',
+            replicate='B df7ebee60a5c',
+        ).exists())
+
+        wrapped_downstream = recursively_wrap_task(psample, TaskThatReliesOnFlagTask, config_path=TEST_CONFIG)
+        self.assertIn('B', [x[0] for x in wrapped_downstream.config.allowed_versions(wrapped_flag_b)])
+        luigi.build([wrapped_downstream], local_scheduler=True)
+        self.assertEqual(wrapped_downstream.flag.version(), 'B')

--- a/tests/test_pangea.py
+++ b/tests/test_pangea.py
@@ -1,12 +1,14 @@
 
 import luigi
 
+from shutil import rmtree
+
 from os import environ, remove
 
 from time import time, sleep
 from cap2.pangea.load_task import PangeaCapTask
 from cap2.pipeline.preprocessing import FastQC
-from unittest import TestCase
+from unittest import TestCase, skip
 from cap2.pangea.cli import set_config
 from cap2.pangea.api import get_task_list_for_sample, wrap_task, recursively_wrap_task
 from cap2.pangea.pangea_sample import PangeaSample
@@ -62,6 +64,14 @@ class DummyFastKraken2(luigi.ExternalTask):
 
 class TestPangea(TestCase):
     """Test the CAP2 API, essentially integration tests."""
+
+    def setUpClass():
+        pass
+        rmtree('.pangea_api_cache')
+
+    def tearDownClass():
+        pass
+        rmtree('test_out')
 
     def test_get_pangea_cap_task_properties(self):
         c = PangeaCapTask.new_task_type(FastQC)
@@ -156,6 +166,37 @@ class TestPangea(TestCase):
         luigi.build(tasks, local_scheduler=True)
         self.assertTrue(PANGEA_SAMPLE.analysis_result('cap2::basic_sample_stats').exists())
 
+    def test_load_task_versions(self):
+        psample = PangeaSample(
+            PANGEA_SAMPLE.uuid,
+            None,
+            None,
+            None,
+            None,
+            None,
+            knex=PANGEA_SAMPLE.knex,
+            sample=PANGEA_SAMPLE,
+        )
+        set_config(PANGEA_ENDPOINT, PANGEA_USER, PANGEA_PASS, '', '', name_is_uuid=True)
+        wrapped_flag_b = wrap_task(psample, FlagTaskVersionB, config_path=TEST_CONFIG, check_versions=False)
+        luigi.build([wrapped_flag_b], local_scheduler=True)
+        remove(wrapped_flag_b.flag_filepath)
+        self.assertTrue(PANGEA_SAMPLE.analysis_result(
+            'cap2::test_flag',
+            replicate='B df7ebee60a5c',
+        ).exists())
+
+        instance = recursively_wrap_task(psample, TaskThatReliesOnFlagTask, config_path=TEST_CONFIG)
+        self.assertEqual(instance.flag.version(), 'B')
+        ivt = instance.version_tree()
+        cvt = TaskThatReliesOnFlagTask.version_tree()
+        self.assertNotEqual(ivt, cvt)
+        self.assertEqual(
+            instance.version_tree().replace('==B', '==A'),
+            TaskThatReliesOnFlagTask.version_tree()
+        )
+        self.assertNotEqual(instance.version_hash(), TaskThatReliesOnFlagTask.version_hash())
+
     def test_pangea_versions(self):
         psample = PangeaSample(
             PANGEA_SAMPLE.uuid,
@@ -180,3 +221,6 @@ class TestPangea(TestCase):
         self.assertIn('B', [x[0] for x in wrapped_downstream.config.allowed_versions(wrapped_flag_b)])
         luigi.build([wrapped_downstream], local_scheduler=True)
         self.assertEqual(wrapped_downstream.flag.version(), 'B')
+        self.assertTrue(PANGEA_SAMPLE.analysis_result(
+            'cap2::test_task_that_relies_on_flag',
+        ).exists())

--- a/tests/test_pangea.py
+++ b/tests/test_pangea.py
@@ -26,7 +26,7 @@ RAW_READS_2 = join(dirname(__file__), 'data/zymo_pos_cntrl.r2.fq.gz')
 TEST_CONFIG = join(dirname(__file__), 'data/test_config.yaml')
 
 PANGEA_ENDPOINT = 'https://pangea.gimmebio.com'
-PANGEA_USER = 'dcdanko@gmail.com'  #'cap2tester@fake.com'
+PANGEA_USER = 'cap2tester@fake.com'
 PANGEA_PASS = environ['CAP2_PANGEA_TEST_PASSWORD']
 
 

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -1,0 +1,132 @@
+
+import luigi
+
+from shutil import rmtree
+from os.path import join, dirname, isfile, isdir
+from unittest import TestCase, skip
+
+from cap2.pipeline.utils.cap_task import CapTask, class_or_instancemethod
+
+RAW_READS_1 = join(dirname(__file__), 'data/zymo_pos_cntrl.r1.fq.gz')
+RAW_READS_2 = join(dirname(__file__), 'data/zymo_pos_cntrl.r2.fq.gz')
+TEST_CONFIG = join(dirname(__file__), 'data/test_config.yaml')
+
+
+class FlagTask(CapTask):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    @classmethod
+    def _module_name(cls):
+        return 'test_flag'
+
+    @property
+    def flag_filepath(self):
+        return self.output()['flag'].path
+
+    def output(self):
+        return {
+            'flag': self.get_target('flag', 'flag'),
+        }
+
+    def _run(self):
+        open(self.flag_filepath, 'w').close()
+
+    @classmethod
+    def dependencies(cls):
+        return []
+
+
+class FlagTaskVersionA(FlagTask):
+    MODULE_VERSION = 'A'
+
+
+class FlagTaskVersionB(FlagTask):
+    MODULE_VERSION = 'B'
+
+
+class TaskThatReliesOnFlagTask(CapTask):
+    MODULE_VERSION = 'v0.1.0'
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.flag = FlagTaskVersionA.from_cap_task(self)
+
+    @classmethod
+    def _module_name(cls):
+        return 'test_task_that_relies_on_flag'
+
+    def requires(self):
+        return self.flag
+
+    @classmethod
+    def dependencies(cls):
+        return [FlagTaskVersionA]
+
+    @property
+    def flag_filepath(self):
+        return self.output()['flag'].path
+
+    def output(self):
+        return {
+            'flag': self.get_target('flag', 'flag'),
+        }
+
+    def _run(self):
+        open(self.flag_filepath, 'w').close()
+
+
+class TestVersion(TestCase):
+
+    def tearDownClass():
+        pass
+        rmtree('test_out')
+
+    def test_create_flag_a(self):
+        flag_a = FlagTaskVersionA(
+            pe1=RAW_READS_1,
+            pe2=RAW_READS_2,
+            sample_name='test_sample',
+            config_filename=TEST_CONFIG,
+            check_versions=False,
+        )
+        self.assertFalse(flag_a.check_versions)
+        self.assertEqual(flag_a.version(), 'A')
+
+    def test_invoke_kraken2(self):
+        flag_b = FlagTaskVersionB(
+            pe1=RAW_READS_1,
+            pe2=RAW_READS_2,
+            sample_name='test_sample',
+            config_filename=TEST_CONFIG
+        )
+        luigi.build([flag_b], local_scheduler=True)
+        self.assertTrue(isfile(flag_b.flag_filepath))
+        instance = TaskThatReliesOnFlagTask(
+            pe1=RAW_READS_1,
+            pe2=RAW_READS_2,
+            sample_name='test_sample',
+            config_filename=TEST_CONFIG
+        )
+        # By default relies on A but config is set to allow B
+        self.assertIn('B', instance.config.allowed_versions(flag_b))
+        self.assertEqual(instance.flag.version(), 'B')
+        luigi.build([instance], local_scheduler=True)
+
+        # check that FlagA is unaffected (no side effects)
+        self.assertEqual(FlagTaskVersionA.version(), 'A')
+        flag_a = FlagTaskVersionA(
+            pe1=RAW_READS_1,
+            pe2=RAW_READS_2,
+            sample_name='different_sample',  # NB if sample is the same luigi will just use the old task
+            config_filename=TEST_CONFIG,
+            check_versions=False,
+        )
+        self.assertFalse(flag_a.check_versions)
+        self.assertIsNone(flag_a.version_override)
+        self.assertEqual(flag_a.version(), 'A')
+        self.assertFalse(isfile(flag_a.flag_filepath))
+
+
+

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -94,7 +94,29 @@ class TestVersion(TestCase):
         self.assertFalse(flag_a.check_versions)
         self.assertEqual(flag_a.version(), 'A')
 
-    def test_invoke_kraken2(self):
+    def test_version_tree_changed(self):
+        flag_b = FlagTaskVersionB(
+            pe1=RAW_READS_1,
+            pe2=RAW_READS_2,
+            sample_name='test_sample',
+            config_filename=TEST_CONFIG,
+            check_versions=False,
+        )
+        luigi.build([flag_b], local_scheduler=True)
+        instance = TaskThatReliesOnFlagTask(
+            pe1=RAW_READS_1,
+            pe2=RAW_READS_2,
+            sample_name='test_sample',
+            config_filename=TEST_CONFIG
+        )
+        self.assertNotEqual(instance.version_tree(), TaskThatReliesOnFlagTask.version_tree())
+        self.assertEqual(
+            instance.version_tree().replace('==B', '==A'),
+            TaskThatReliesOnFlagTask.version_tree()
+        )
+        self.assertNotEqual(instance.version_hash(), TaskThatReliesOnFlagTask.version_hash())
+
+    def test_sub_version(self):
         flag_b = FlagTaskVersionB(
             pe1=RAW_READS_1,
             pe2=RAW_READS_2,

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -99,7 +99,8 @@ class TestVersion(TestCase):
             pe1=RAW_READS_1,
             pe2=RAW_READS_2,
             sample_name='test_sample',
-            config_filename=TEST_CONFIG
+            config_filename=TEST_CONFIG,
+            check_versions=False,
         )
         luigi.build([flag_b], local_scheduler=True)
         self.assertTrue(isfile(flag_b.flag_filepath))
@@ -110,7 +111,7 @@ class TestVersion(TestCase):
             config_filename=TEST_CONFIG
         )
         # By default relies on A but config is set to allow B
-        self.assertIn('B', instance.config.allowed_versions(flag_b))
+        self.assertIn('B', [x[0] for x in instance.config.allowed_versions(flag_b)])
         self.assertEqual(instance.flag.version(), 'B')
         luigi.build([instance], local_scheduler=True)
 


### PR DESCRIPTION
In many cases we want to run a downstream task without re-running upstream tasks to save compute. Currently this is not possible as tasks are hard coded to look for ONLY the newest version of the tasks it depends on in the filesystem/pangea. This PR will allow tasks to look for arbitrary versions of tasks they rely on.

The caveat to this is that modules will not be able to find old versions if the fields for those versions have changed since without a much more complicated system (that integrates old code) the modules can't know that the old fields existed. In practice this can be mitigated using pipeline stages as e.g. the `CleanReads` module is unlikely to add new fields ever.

Approach:
1) check if a particular version exists based on a version string and version hash
2) if the version exists spoof those into the object

The spoofing in approach seems to introduce some pitfalls. Mainly have to be careful that we haven't reverted to the newest version by reinstantiating the task or similar.