### PR TITLE
Add support for work orders to the MCAP

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import setuptools
 
 setuptools.setup(
     name='cap2',
-    version='0.3.0',
+    version='0.4.1',
     description="CAP2",
     author="David C. Danko",
     author_email='dcdanko@gmail.com',


### PR DESCRIPTION
Add prelim support for Pangea work orders to the MCAP.

Work orders are a Pangea feature that allows a Pangea user to order work and track the progress of that work. This PR adds support to find new work orders and update work orders when jobs are completed.